### PR TITLE
issue #19 fix: remove verified publisher, cncf, official icons

### DIFF
--- a/src/components/KaitoModels.tsx
+++ b/src/components/KaitoModels.tsx
@@ -56,9 +56,7 @@ interface PresetModel {
     name: string;
     url: string;
   };
-  verifiedPublisher: boolean;
-  official: boolean;
-  cncf: boolean;
+
   logoImageId: string;
   description: string;
   instanceType: string;
@@ -180,9 +178,7 @@ function convertToPresetModels(supportedModels: SupportedModel[]): PresetModel[]
         name: getCompanyName(model.name),
         url: getHuggingFaceUrl(model.name),
       },
-      verifiedPublisher: true,
-      official: i % 3 === 0,
-      cncf: i % 4 === 0,
+
       logoImageId: getLogo(model.name),
       description: getModelDescription(model.name),
       instanceType: getInstanceType(model.name),


### PR DESCRIPTION
Removed verified publisher, cncf, official icons as they are not significant in this context. In response to https://github.com/kaito-project/headlamp-kaito/issues/19
