### PR TITLE
feat: update documentation with mcp testing support for port-forwarding, local in-cluster, and external testing 

### DIFF
--- a/website/docs/features/testing-mcp-server.md
+++ b/website/docs/features/testing-mcp-server.md
@@ -121,16 +121,12 @@ spec:
           ports:
             - containerPort: 8080
           env:
-            - name: ENABLE_UNSAFE_SSE_TRANSPORT
-              value: '1'
             - name: HOST
               value: '0.0.0.0'
             - name: PORT
               value: '8080'
-            - name: DANGEROUSLY_OMIT_AUTH
-              value: 'true'
             - name: ALLOWED_ORIGINS
-              value: '*'
+              value: "*"
 ---
 apiVersion: v1
 kind: Service

--- a/website/docs/features/testing-mcp-server.md
+++ b/website/docs/features/testing-mcp-server.md
@@ -247,50 +247,22 @@ Apply and restart:
 kubectl apply -f mcp-inspector.yaml
 kubectl rollout restart deployment mcp-inspector
 ```
-
-Then run
-
+To see the status of your pod services, run:
 ```
-kubectl logs deployment/mcp-inspector
+kubectl run service
 ```
 
-and you will see something like this:
+Then port-forward the MCP-Inspector to a local port:
 
 ```
-Starting MCP inspector...
-⚙️ Proxy server listening on 0.0.0.0:6277
-🔑 Session token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-   Use this token to authenticate requests or set DANGEROUSLY_OMIT_AUTH=true to disable auth
-
-🚀 MCP Inspector is up and running at:
-   http://0.0.0.0:6274/?MCP_PROXY_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+kubectl port-forward service/mcp-inspector 6274:6274 6277:6277
 ```
 
-Then get the external IP by running:
-
-```bash
-kubectl get service mcp-inspector
-```
-
-Your output should look like this:
+Once that is running, navigate to
 
 ```
-NAME            TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)                         AGE
-mcp-inspector   LoadBalancer   10.0.211.173   20.83.66.22   6274:30572/TCP,6277:32271/TCP   5d10h
+http://localhost:6274/
 ```
-
-Navigate to
-
-```
-http://<external_ip>:<port>/?MCP_PROXY_AUTH_TOKEN=<token>
-```
-
-for example:
-
-```
-http://20.83.66.22:6274/?MCP_PROXY_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#tools
-```
-
 ## 5. Testing
 
 In the in the browser Inspector UI:

--- a/website/docs/features/testing-mcp-server.md
+++ b/website/docs/features/testing-mcp-server.md
@@ -375,7 +375,7 @@ spec:
             - name: NO_AUTH
               value: 'true'
             - name: ALLOWED_ORIGINS
-              value: 'http://<mcp-inspector-EXTERNAL-IP>:6274,http://localhost:6274,*'
+              value: 'http://<mcp-inspector-EXTERNAL-IP>:6274,http://localhost:6274,*' # Replace <mcp-inspector-EXTERNAL-IP> with the external IP address of the mcp-inspector service
 ---
 apiVersion: v1
 kind: Service

--- a/website/docs/features/testing-mcp-server.md
+++ b/website/docs/features/testing-mcp-server.md
@@ -210,20 +210,24 @@ spec:
           image: ghcr.io/modelcontextprotocol/inspector:latest
           ports:
             - containerPort: 6274
+            - containerPort: 6277
           env:
             - name: MCP_URL
               value: 'http://kubernetes-mcp-server:8080/mcp'
             - name: HOST
               value: '0.0.0.0'
+            - name: PORT
+              value: '6277'
+            - name: DANGEROUSLY_OMIT_AUTH
+              value: 'true'
             - name: ALLOWED_ORIGINS
-              value: 'http://20.83.66.22:6274'
+              value: 'http://localhost:6274'
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: mcp-inspector
 spec:
-  type: LoadBalancer
   selector:
     app: mcp-inspector
   ports:

--- a/website/docs/features/testing-mcp-server.md
+++ b/website/docs/features/testing-mcp-server.md
@@ -258,6 +258,8 @@ Then port-forward the MCP-Inspector to a local port:
 kubectl port-forward service/mcp-inspector 6274:6274 6277:6277
 ```
 
+**Note**: Port forwarding only works while the command is running and only from the machine running the command.
+
 Once that is running, navigate to
 
 ```
@@ -440,25 +442,11 @@ kubectl get service kubernetes-mcp-server
 
 Use the external IP in Headlamp-KAITO: `http://EXTERNAL-IP:8080/mcp`
 
-### Option 2: Port Forwarding (Recommended for Security)
-
-**🔒 Secure Option**: Port forwarding keeps your MCP server private and only accessible from your local machine.
-
-If you're using a local cluster or want to test without exposing the service publicly:
-
-```bash
-kubectl port-forward service/kubernetes-mcp-server 8080:8080
-```
-
-Then use in Headlamp-KAITO: `http://localhost:8080/mcp`
-
-**Note**: Port forwarding only works while the command is running and only from the machine running the command.
 
 1. Open Headlamp-KAITO and navigate to a chat interface with a tool-enabled model (Llama models)
 2. Click the **MCP Chip** in the chat header to open the MCP Server Management interface
 3. Add your MCP server using the appropriate endpoint URL:
    - **LoadBalancer**: `http://EXTERNAL-IP:8080/mcp` (get external IP with `kubectl get service kubernetes-mcp-server`)
-   - **Port Forward**: `http://localhost:8080/mcp` (requires active port-forward session)
 
 ### 2. Configuration Tips
 

--- a/website/docs/features/testing-mcp-server.md
+++ b/website/docs/features/testing-mcp-server.md
@@ -5,6 +5,7 @@ sidebar_position: 4
 # Testing your MCP Server
 
 Before connecting your MCP server to Headlamp-KAITO, it's recommended to test it independently to ensure it's working correctly. This guide provides a complete walkthrough for testing a Kubernetes MCP Server using the MCP Inspector UI.
+> **Note:** Headlamp-KAITO allows you to test MCP Server tool calling support, but does not currently support deploying MCP servers to your cluster. Deployment support is coming soon!
 
 ## Why Test Your MCP Server First?
 


### PR DESCRIPTION
Recommended testing: 
- port-forward MCP Inspector to local port and test in-cluster communication between MCP-Inspector and kubernetes-mcp-server.
Other supported methods: 
- full in-cluster communication (if Headlamp is installed in-cluster)
- hosting mcp externally (if Headlamp is installed as an external browser) 