### PR TITLE
feat: add configurable params topP and topK to model settings

### DIFF
--- a/src/components/ChatUI.tsx
+++ b/src/components/ChatUI.tsx
@@ -177,7 +177,7 @@ const ChatUI: React.FC<ChatUIProps & { embedded?: boolean }> = ({
   const theme = themeProp || useTheme();
   const [config, setConfig] = useState<ModelConfig>(DEFAULT_OPENAI_CONFIG);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const { temperature = 0.7, maxTokens = 1000 } = config || {};
+  const { temperature = 0.7, maxTokens = 1000, topP = 1.0, topK = 0 } = config || {};
   const [messages, setMessages] = useState<Message[]>([
     {
       id: 'welcome',
@@ -321,6 +321,8 @@ const ChatUI: React.FC<ChatUIProps & { embedded?: boolean }> = ({
         messages: conversationHistory,
         temperature,
         maxTokens,
+        topP,
+        topK,
         maxSteps: 5,
         tools: mcpTools,
       });

--- a/src/components/ModelSettingsDialog.tsx
+++ b/src/components/ModelSettingsDialog.tsx
@@ -12,6 +12,8 @@ import React from 'react';
 export interface ModelConfig {
   temperature: number;
   maxTokens: number;
+  topP: number;
+  topK: number;
 }
 
 interface Props {
@@ -22,7 +24,7 @@ interface Props {
 }
 
 const ModelSettingsDialog: React.FC<Props> = ({ open, onClose, config, onSave }) => {
-  const defaultConfig = { temperature: 0.7, maxTokens: 1000 };
+  const defaultConfig = { temperature: 0.7, maxTokens: 1000, topP: 1.0, topK: 0 };
   const [localConfig, setLocalConfig] = React.useState(config || defaultConfig);
 
   React.useEffect(() => {
@@ -46,6 +48,16 @@ const ModelSettingsDialog: React.FC<Props> = ({ open, onClose, config, onSave })
     setLocalConfig(prev => ({ ...prev, maxTokens: value }));
   };
 
+  const handleTopPChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseFloat(e.target.value);
+    setLocalConfig(prev => ({ ...prev, topP: value }));
+  };
+
+  const handleTopKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    setLocalConfig(prev => ({ ...prev, topK: value }));
+  };
+
   return (
     <Dialog open={open} onClose={onClose}>
       <DialogTitle>Model Settings</DialogTitle>
@@ -63,7 +75,7 @@ const ModelSettingsDialog: React.FC<Props> = ({ open, onClose, config, onSave })
               style={{ width: '100%' }}
             />
           </Box>
-          <Box mb={2}>
+          <Box mb={3}>
             <Typography gutterBottom>Max Tokens: {localConfig.maxTokens}</Typography>
             <input
               type="range"
@@ -72,6 +84,30 @@ const ModelSettingsDialog: React.FC<Props> = ({ open, onClose, config, onSave })
               step="50"
               value={localConfig.maxTokens}
               onChange={handleMaxTokensChange}
+              style={{ width: '100%' }}
+            />
+          </Box>
+          <Box mb={3}>
+            <Typography gutterBottom>Top P: {localConfig.topP.toFixed(2)}</Typography>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={localConfig.topP}
+              onChange={handleTopPChange}
+              style={{ width: '100%' }}
+            />
+          </Box>
+          <Box mb={2}>
+            <Typography gutterBottom>Top K: {localConfig.topK}</Typography>
+            <input
+              type="range"
+              min="0"
+              max="100"
+              step="1"
+              value={localConfig.topK}
+              onChange={handleTopKChange}
               style={{ width: '100%' }}
             />
           </Box>

--- a/src/config/openai.ts
+++ b/src/config/openai.ts
@@ -1,4 +1,6 @@
 export const DEFAULT_OPENAI_CONFIG = {
   temperature: 0.7,
   maxTokens: 1000,
+  topP: 1.0,
+  topK: 0,
 };

--- a/website/docs/features/core-features.md
+++ b/website/docs/features/core-features.md
@@ -50,7 +50,7 @@ Headlamp-KAITO provides a comprehensive set of features designed to simplify AI 
 ### Model Configuration
 
 - **Model Selection**: Choose from available deployed models
-- **Parameter Tuning**: Adjust temperature, max tokens, and other model parameters
+- **Parameter Tuning**: Adjust temperature, max tokens, top P, top K
 - **Session Management**: Manage multiple chat sessions with different models
 - **Response Formatting**: Customizable response formatting and display options
 

--- a/website/docs/features/custom-fine-tuning.md
+++ b/website/docs/features/custom-fine-tuning.md
@@ -14,6 +14,9 @@ The system provides default configuration values through the DEFAULT_OPENAI_CONF
 | ----------- | ------------- | ----------------------------------------------------------------------------------- |
 | temperature | 0.7           | Controls randomness in AI responses (0.0 = deterministic, 1.0 = maximum randomness) |
 | maxTokens   | 1000          | Maximum number of tokens the AI model can generate in a single response             |
+| top_p       | 1.0           | Controls nucleus sampling; limits responses to the most probable tokens (0.0–1.0)   |
+| top_k       | 0             | Limits responses to the top k most likely tokens (0 = disabled, higher = more focused) |
+
 
 ## Model Setting Configuration
 
@@ -43,6 +46,27 @@ The max tokens parameter limits the length of AI model responses. The configurat
 
 This parameter directly affects response length and computational resource usage during AI interactions.
 
+#### Top P
+
+The top_p parameter controls nucleus sampling, which limits responses to the most probable tokens. In the ModelSettingsDialog, this is configured via a slider with:
+
+- **Range**: 0.0 to 1.0
+- **Step**: 0.01
+- **Default**: 1.0
+- **UI Implementation**: `src/components/ModelSettingsDialog.tsx` (lines 78-88)
+
+Lower values restrict the model to a smaller set of likely tokens, making responses more focused. Higher values allow for more diverse outputs.
+
+#### Top K
+
+The top_k parameter restricts responses to the top k most likely tokens. The ModelSettingsDialog provides a slider for this setting:
+
+- **Range**: 0 to 100
+- **Step**: 1
+- **Default**: 0 (disabled)
+- **UI Implementation**: `src/components/ModelSettingsDialog.tsx` (lines 89-99)
+
+Increasing top_k focuses the model’s output on the most probable tokens, while a value of 0 disables this restriction for broader responses.
 ## Integration with Chat Interface
 
 Once fine-tuning is complete, your custom model can be used in the chat interface:


### PR DESCRIPTION
<img width="524" height="697" alt="image" src="https://github.com/user-attachments/assets/ef84f3ae-3306-4c38-bf39-211d759ec626" />

Added support to customize topP and topK from ai-sdk https://ai-sdk.dev/docs/ai-sdk-core/settings
In response to issue here: https://github.com/kaito-project/headlamp-kaito/issues/60