### PR TITLE
fix: Resolve a11y violations

### DIFF
--- a/src/components/ChatUI.tsx
+++ b/src/components/ChatUI.tsx
@@ -972,7 +972,7 @@ const ChatUI: React.FC<ChatUIProps & { embedded?: boolean }> = ({
                 </IconButton>
               </Tooltip>
               <Tooltip title="Clear conversation">
-                <IconButton onClick={clearChat} size="small">
+                <IconButton onClick={clearChat} size="small" aria-label="Clear conversation">
                   <Icon icon="material-symbols:delete" style={{ fontSize: 20 }} />
                 </IconButton>
               </Tooltip>
@@ -983,6 +983,7 @@ const ChatUI: React.FC<ChatUIProps & { embedded?: boolean }> = ({
                     onClose?.();
                   }}
                   size="small"
+                  aria-label="Close chat"
                   sx={{
                     color: '#ef4444',
                     fontSize: '18px',

--- a/src/components/KaitoModels.tsx
+++ b/src/components/KaitoModels.tsx
@@ -385,7 +385,7 @@ const KaitoModels = () => {
                   >
                     Deploy
                   </Button>
-                  <Link href={model.company.url} target="_blank">
+                  <Link href={model.company.url} target="_blank" rel="noopener noreferrer">
                     Learn More
                   </Link>
                 </CardActions>

--- a/src/components/KaitoWorkspacesList.tsx
+++ b/src/components/KaitoWorkspacesList.tsx
@@ -33,7 +33,7 @@ const KaitoWorkspacesList: React.FC = () => {
               <StatusLabel status={getConditionStatus(condition)}>
                 {(status === 'warning' || status === 'error') && (
                   <Icon
-                    aria-label="hidden"
+                    aria-hidden
                     icon="mdi:alert-outline"
                     width="1.2rem"
                     height="1.2rem"

--- a/src/components/MCPServerManager.tsx
+++ b/src/components/MCPServerManager.tsx
@@ -124,12 +124,15 @@ const MCPServerManager: React.FC<MCPServerManagerProps> = ({
                 <Checkbox
                   checked={server.enabled}
                   onChange={() => handleToggleServer(server.id)}
+                  inputProps={{ 'aria-label': `Enable ${server.name}` }}
                   sx={{ mr: 2 }}
                 />
                 <ListItemText
                   primary={
                     <Stack direction="row" spacing={1} alignItems="center">
-                      <Typography variant="subtitle1">{server.name}</Typography>
+                      <Typography variant="subtitle1" component="span">
+                        {server.name}
+                      </Typography>
                       <Chip
                         label={server.transportType || 'streamableHttp'}
                         color="info"
@@ -152,10 +155,18 @@ const MCPServerManager: React.FC<MCPServerManagerProps> = ({
                   }
                 />
                 <ListItemSecondaryAction>
-                  <IconButton onClick={() => handleEditServer(server)} size="small">
+                  <IconButton
+                    onClick={() => handleEditServer(server)}
+                    size="small"
+                    aria-label={`Edit ${server.name}`}
+                  >
                     <Icon icon="material-symbols:edit" style={{ fontSize: 20 }} />
                   </IconButton>
-                  <IconButton onClick={() => handleDeleteServer(server.id)} size="small">
+                  <IconButton
+                    onClick={() => handleDeleteServer(server.id)}
+                    size="small"
+                    aria-label={`Delete ${server.name}`}
+                  >
                     <Icon icon="material-symbols:delete" style={{ fontSize: 20 }} />
                   </IconButton>
                 </ListItemSecondaryAction>

--- a/src/components/ModelSettingsDialog.tsx
+++ b/src/components/ModelSettingsDialog.tsx
@@ -72,6 +72,7 @@ const ModelSettingsDialog: React.FC<Props> = ({ open, onClose, config, onSave })
               step="0.01"
               value={localConfig.temperature}
               onChange={handleTemperatureChange}
+              aria-label="Temperature"
               style={{ width: '100%' }}
             />
           </Box>
@@ -84,6 +85,7 @@ const ModelSettingsDialog: React.FC<Props> = ({ open, onClose, config, onSave })
               step="50"
               value={localConfig.maxTokens}
               onChange={handleMaxTokensChange}
+              aria-label="Max Tokens"
               style={{ width: '100%' }}
             />
           </Box>
@@ -96,6 +98,7 @@ const ModelSettingsDialog: React.FC<Props> = ({ open, onClose, config, onSave })
               step="0.01"
               value={localConfig.topP}
               onChange={handleTopPChange}
+              aria-label="Top P"
               style={{ width: '100%' }}
             />
           </Box>
@@ -108,6 +111,7 @@ const ModelSettingsDialog: React.FC<Props> = ({ open, onClose, config, onSave })
               step="1"
               value={localConfig.topK}
               onChange={handleTopKChange}
+              aria-label="Top K"
               style={{ width: '100%' }}
             />
           </Box>


### PR DESCRIPTION
These changes fix accessibility (a11y) violations in headlamp-kaito surfaced by an axe-core pass over the components. The plugin looks and behaves exactly as before for sighted mouse users, while becoming usable for keyboard and screen-reader users.

Fixes: #72 

### Changes

- Add accessible names to the chat toolbar's icon-only buttons and to the model settings sliders
- Add accessible names to the MCP server enable toggle and its edit/delete controls
- Give the model "Learn More" link `rel="noopener noreferrer"`
- Replace `aria-label="hidden"` on a decorative status icon with `aria-hidden` so it is ignored rather than announced
- Adjust the MCP server name so headings follow a valid order